### PR TITLE
Fixed: Trying to access array offset on value of type bool

### DIFF
--- a/lessc.inc.php
+++ b/lessc.inc.php
@@ -662,7 +662,7 @@ class lessc {
 
         // check for a rest
         $last = end($args);
-        if ($last[0] == "rest") {
+        if (is_array($last) && $last[0] == "rest") {
             $rest = array_slice($orderedValues, count($args) - 1);
             $this->set($last[1], $this->reduce(array("list", " ", $rest)));
         }


### PR DESCRIPTION
Fix for a minor issue. $args array can be empty, so there was a check of first array member on an empty array.